### PR TITLE
Added a no-std attribute to the crate root.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Marc Brinkmann <git@marcbrinkmann.de>"]
 repository = "https://github.com/mbr/pid_control-rs"
 documentation = "http://mbr.github.io/pid_control-rs/pid_control/"
 description = """A PID controller library"""
+categories = ["no-std"]
+
 license = "MIT"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,11 @@
 
 // FIXME: it may be worth to explore http://de.mathworks.com/help/simulink/slref/pidcontroller.html
 //        for additional features/inspiration
-
-extern crate core;
+#![no_std]
 
 pub mod util;
 
-use std::f64;
+use core::f64;
 
 /// A generic controller interface.
 ///


### PR DESCRIPTION
I'd like to use this library in an embedded project so I added a `no-std` attribute to the crate root.